### PR TITLE
ESD-2716-fork-resvg-0-36-add-text-serialization-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 This changelog also contains important changes in dependencies.
 
-## [Unreleased]
+## [Unreleased] - 2024-08-30
+### Added
+- Text node serialization.
 
 ## [0.36.0] - 2023-10-01
 ### Added


### PR DESCRIPTION
Added text node serialization.

Moved path data serialization into new function so that it can be used when serializing textPaths.

Added textPath serialization within svg 'defs' node.