### PR TITLE
ESD-2903-resvg-parsing-font-family-incorrectly

### DIFF
--- a/crates/usvg-parser/src/font.rs
+++ b/crates/usvg-parser/src/font.rs
@@ -1,0 +1,109 @@
+// Copyright 2024 the SVG Types Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::stream::{ByteExt, Stream};
+use crate::Error;
+
+/// Parses a list of font families and generic families from a string.
+pub fn parse_font_families(text: &str) -> Result<Vec<FontFamily>, Error> {
+    let mut s = Stream::from(text);
+    let font_families = s.parse_font_families()?;
+
+    s.skip_spaces();
+    if !s.at_end() {
+        return Err(Error::UnexpectedData(s.calc_char_pos()));
+    }
+
+    Ok(font_families)
+}
+
+/// A type of font family.
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+pub enum FontFamily {
+    /// A serif font.
+    Serif,
+    /// A sans-serif font.
+    SansSerif,
+    /// A cursive font.
+    Cursive,
+    /// A fantasy font.
+    Fantasy,
+    /// A monospace font.
+    Monospace,
+    /// A custom named font.
+    Named(String),
+}
+
+impl ToString for FontFamily {
+    fn to_string(&self) -> String {
+        match self {
+            FontFamily::Serif => "serif".to_string(),
+            FontFamily::SansSerif => "sans-serif".to_string(),
+            FontFamily::Cursive => "cursive".to_string(),
+            FontFamily::Fantasy => "fantasy".to_string(),
+            FontFamily::Monospace => "monospace".to_string(),
+            FontFamily::Named(name) => name.clone(),
+        }
+    }
+}
+
+impl Stream<'_> {
+    pub fn parse_font_families(&mut self) -> Result<Vec<FontFamily>, Error> {
+        let mut families = vec![];
+
+        while !self.at_end() {
+            self.skip_spaces();
+
+            let family = {
+                let ch = self.curr_byte()?;
+                if ch == b'\'' || ch == b'\"' {
+                    let res = self.parse_quoted_string()?;
+                    FontFamily::Named(res.to_string())
+                } else {
+                    let mut idents = vec![];
+
+                    while let Some(c) = self.chars().next() {
+                        if c != ',' {
+                            idents.push(self.parse_ident()?.to_string());
+                            self.skip_spaces();
+                        } else {
+                            break;
+                        }
+                    }
+
+                    let joined = idents.join(" ");
+
+                    // TODO: No CSS keyword must be matched as a family name...
+                    match joined.as_str() {
+                        "serif" => FontFamily::Serif,
+                        "sans-serif" => FontFamily::SansSerif,
+                        "cursive" => FontFamily::Cursive,
+                        "fantasy" => FontFamily::Fantasy,
+                        "monospace" => FontFamily::Monospace,
+                        _ => FontFamily::Named(joined),
+                    }
+                }
+            };
+
+            families.push(family);
+
+            if let Ok(b) = self.curr_byte() {
+                if b == b',' {
+                    self.advance(1);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        let families = families
+            .into_iter()
+            .filter(|f| match f {
+                FontFamily::Named(s) => !s.is_empty(),
+                _ => true,
+            })
+            .collect();
+
+        Ok(families)
+    }
+}

--- a/crates/usvg-parser/src/font.rs
+++ b/crates/usvg-parser/src/font.rs
@@ -1,6 +1,10 @@
 // Copyright 2024 the SVG Types Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// cmccall: Copied in from svgtypes repo b1cd4010f5e42f970932dbf01acc8f53547f64f6
+// Brought this in so that I could use parse_font_families. If possible, we may
+// want to consider updating the svgtypes crate dependency to 15.2+.
+
 use crate::stream::{ByteExt, Stream};
 use crate::Error;
 

--- a/crates/usvg-parser/src/lib.rs
+++ b/crates/usvg-parser/src/lib.rs
@@ -36,14 +36,21 @@ mod switch;
 mod text;
 mod units;
 mod use_node;
+mod font;
+mod stream;
+mod number;
+
+use crate::stream::{ByteExt, Stream};
 
 pub use crate::options::*;
 pub use image::ImageHrefResolver;
 pub use roxmltree;
 pub use svgtree::{AId, EId};
+pub use crate::font::*;
+pub use crate::number::*;
 
 /// List of all errors.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     /// Only UTF-8 content are supported.
     NotAnUtf8Str,
@@ -60,6 +67,46 @@ pub enum Error {
     ///
     /// Also occurs if width, height and viewBox are not set.
     InvalidSize,
+        /// An input data ended earlier than expected.
+    ///
+    /// Should only appear on invalid input data.
+    /// Errors in a valid XML should be handled by errors below.
+    UnexpectedEndOfStream,
+
+    /// An input text contains unknown data.
+    UnexpectedData(usize),
+
+    /// A provided string doesn't have a valid data.
+    ///
+    /// For example, if we try to parse a color form `zzz`
+    /// string - we will get this error.
+    /// But if we try to parse a number list like `1.2 zzz`,
+    /// then we will get `InvalidNumber`, because at least some data is valid.
+    InvalidValue,
+
+    /// An invalid ident.
+    ///
+    /// CSS idents have certain rules with regard to the characters they may contain.
+    /// For example, they may not start with a number. If an invalid ident is encountered,
+    /// this error will be returned.
+    InvalidIdent,
+
+    /// An invalid/unexpected character.
+    ///
+    /// The first byte is an actual one, others - expected.
+    ///
+    /// We are using a single value to reduce the struct size.
+    InvalidChar(Vec<u8>, usize),
+
+    /// An unexpected character instead of an XML space.
+    ///
+    /// The first string is an actual one, others - expected.
+    ///
+    /// We are using a single value to reduce the struct size.
+    InvalidString(Vec<String>, usize),
+
+    /// An invalid number.
+    InvalidNumber(usize),
 
     /// Failed to parse an SVG data.
     ParsingFailed(roxmltree::Error),
@@ -88,6 +135,46 @@ impl std::fmt::Display for Error {
             }
             Error::ParsingFailed(ref e) => {
                 write!(f, "SVG data parsing failed cause {}", e)
+            }
+            Error::UnexpectedEndOfStream => {
+                write!(f, "unexpected end of stream")
+            }
+            Error::UnexpectedData(pos) => {
+                write!(f, "unexpected data at position {}", pos)
+            }
+            Error::InvalidValue => {
+                write!(f, "invalid value")
+            }
+            Error::InvalidIdent => {
+                write!(f, "invalid ident")
+            }
+            Error::InvalidChar(ref chars, pos) => {
+                // Vec<u8> -> Vec<String>
+                let list: Vec<String> = chars
+                    .iter()
+                    .skip(1)
+                    .map(|c| String::from_utf8(vec![*c]).unwrap())
+                    .collect();
+
+                write!(
+                    f,
+                    "expected '{}' not '{}' at position {}",
+                    list.join("', '"),
+                    chars[0] as char,
+                    pos
+                )
+            }
+            Error::InvalidString(ref strings, pos) => {
+                write!(
+                    f,
+                    "expected '{}' not '{}' at position {}",
+                    strings[1..].join("', '"),
+                    strings[0],
+                    pos
+                )
+            }
+            Error::InvalidNumber(pos) => {
+                write!(f, "invalid number at position {}", pos)
             }
         }
     }

--- a/crates/usvg-parser/src/lib.rs
+++ b/crates/usvg-parser/src/lib.rs
@@ -24,30 +24,30 @@
 mod clippath;
 mod converter;
 mod filter;
+mod font;
 mod image;
 mod marker;
 mod mask;
+mod number;
 mod options;
 mod paint_server;
 mod shapes;
+mod stream;
 mod style;
 mod svgtree;
 mod switch;
 mod text;
 mod units;
 mod use_node;
-mod font;
-mod stream;
-mod number;
 
 use crate::stream::{ByteExt, Stream};
 
+pub use crate::font::*;
+pub use crate::number::*;
 pub use crate::options::*;
 pub use image::ImageHrefResolver;
 pub use roxmltree;
 pub use svgtree::{AId, EId};
-pub use crate::font::*;
-pub use crate::number::*;
 
 /// List of all errors.
 #[derive(Debug, PartialEq, Eq)]
@@ -67,7 +67,7 @@ pub enum Error {
     ///
     /// Also occurs if width, height and viewBox are not set.
     InvalidSize,
-        /// An input data ended earlier than expected.
+    /// An input data ended earlier than expected.
     ///
     /// Should only appear on invalid input data.
     /// Errors in a valid XML should be handled by errors below.

--- a/crates/usvg-parser/src/number.rs
+++ b/crates/usvg-parser/src/number.rs
@@ -1,6 +1,10 @@
 // Copyright 2018 the SVG Types Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// cmccall: Copied in from svgtypes repo b1cd4010f5e42f970932dbf01acc8f53547f64f6
+// Brought this in so that I could use parse_font_families. If possible, we may
+// want to consider updating the svgtypes crate dependency to 15.2+.
+
 use std::str::FromStr;
 
 use crate::{ByteExt, Error, Stream};

--- a/crates/usvg-parser/src/number.rs
+++ b/crates/usvg-parser/src/number.rs
@@ -1,0 +1,224 @@
+// Copyright 2018 the SVG Types Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use std::str::FromStr;
+
+use crate::{ByteExt, Error, Stream};
+
+/// An [SVG number](https://www.w3.org/TR/SVG2/types.html#InterfaceSVGNumber).
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Number(pub f64);
+
+impl std::str::FromStr for Number {
+    type Err = Error;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        let mut s = Stream::from(text);
+        let n = s.parse_number()?;
+        s.skip_spaces();
+        if !s.at_end() {
+            return Err(Error::UnexpectedData(s.calc_char_pos()));
+        }
+
+        Ok(Self(n))
+    }
+}
+
+impl Stream<'_> {
+    /// Parses number from the stream.
+    ///
+    /// This method will detect a number length and then
+    /// will pass a substring to the `f64::from_str` method.
+    ///
+    /// <https://www.w3.org/TR/SVG2/types.html#InterfaceSVGNumber>
+    ///
+    /// # Errors
+    ///
+    /// Returns only `InvalidNumber`.
+    pub fn parse_number(&mut self) -> Result<f64, Error> {
+        // Strip off leading whitespaces.
+        self.skip_spaces();
+
+        let start = self.pos();
+
+        if self.at_end() {
+            return Err(Error::InvalidNumber(self.calc_char_pos_at(start)));
+        }
+
+        self.parse_number_impl()
+            .map_err(|_| Error::InvalidNumber(self.calc_char_pos_at(start)))
+    }
+
+    fn parse_number_impl(&mut self) -> Result<f64, Error> {
+        let start = self.pos();
+
+        let mut c = self.curr_byte()?;
+
+        // Consume sign.
+        if c.is_sign() {
+            self.advance(1);
+            c = self.curr_byte()?;
+        }
+
+        // Consume integer.
+        match c {
+            b'0'..=b'9' => self.skip_digits(),
+            b'.' => {}
+            _ => return Err(Error::InvalidNumber(0)),
+        }
+
+        // Consume fraction.
+        if let Ok(b'.') = self.curr_byte() {
+            self.advance(1);
+            self.skip_digits();
+        }
+
+        if let Ok(c) = self.curr_byte() {
+            if matches!(c, b'e' | b'E') {
+                let c2 = self.next_byte()?;
+                // Check for `em`/`ex`.
+                if c2 != b'm' && c2 != b'x' {
+                    self.advance(1);
+
+                    match self.curr_byte()? {
+                        b'+' | b'-' => {
+                            self.advance(1);
+                            self.skip_digits();
+                        }
+                        b'0'..=b'9' => self.skip_digits(),
+                        _ => {
+                            return Err(Error::InvalidNumber(0));
+                        }
+                    }
+                }
+            }
+        }
+
+        let s = self.slice_back(start);
+
+        // Use the default f64 parser now.
+        if let Ok(n) = f64::from_str(s) {
+            // inf, nan, etc. are an error.
+            if n.is_finite() {
+                return Ok(n);
+            }
+        }
+
+        Err(Error::InvalidNumber(0))
+    }
+
+    /// Parses number from a list of numbers.
+    pub fn parse_list_number(&mut self) -> Result<f64, Error> {
+        if self.at_end() {
+            return Err(Error::UnexpectedEndOfStream);
+        }
+
+        let n = self.parse_number()?;
+        self.skip_spaces();
+        self.parse_list_separator();
+        Ok(n)
+    }
+}
+
+/// A pull-based [`<list-of-numbers>`] parser.
+///
+/// # Examples
+///
+/// ```
+/// use svgtypes::NumberListParser;
+///
+/// let mut p = NumberListParser::from("10, 20 -50");
+/// assert_eq!(p.next().unwrap().unwrap(), 10.0);
+/// assert_eq!(p.next().unwrap().unwrap(), 20.0);
+/// assert_eq!(p.next().unwrap().unwrap(), -50.0);
+/// assert_eq!(p.next().is_none(), true);
+/// ```
+///
+/// [`<list-of-numbers>`]: https://www.w3.org/TR/SVG2/types.html#InterfaceSVGNumberList
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct NumberListParser<'a>(Stream<'a>);
+
+impl<'a> From<&'a str> for NumberListParser<'a> {
+    #[inline]
+    fn from(v: &'a str) -> Self {
+        NumberListParser(Stream::from(v))
+    }
+}
+
+impl Iterator for NumberListParser<'_> {
+    type Item = Result<f64, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0.at_end() {
+            None
+        } else {
+            let v = self.0.parse_list_number();
+            if v.is_err() {
+                self.0.jump_to_end();
+            }
+
+            Some(v)
+        }
+    }
+}
+
+#[rustfmt::skip]
+#[cfg(test)]
+mod tests {
+    use crate::Stream;
+
+    macro_rules! test_p {
+        ($name:ident, $text:expr, $result:expr) => (
+            #[test]
+            fn $name() {
+                let mut s = Stream::from($text);
+                assert_eq!(s.parse_number().unwrap(), $result);
+            }
+        )
+    }
+
+    test_p!(parse_1,  "0", 0.0);
+    test_p!(parse_2,  "1", 1.0);
+    test_p!(parse_3,  "-1", -1.0);
+    test_p!(parse_4,  " -1 ", -1.0);
+    test_p!(parse_5,  "  1  ", 1.0);
+    test_p!(parse_6,  ".4", 0.4);
+    test_p!(parse_7,  "-.4", -0.4);
+    test_p!(parse_8,  "-.4text", -0.4);
+    test_p!(parse_9,  "-.01 text", -0.01);
+    test_p!(parse_10, "-.01 4", -0.01);
+    test_p!(parse_11, ".0000000000008", 0.0000000000008);
+    test_p!(parse_12, "1000000000000", 1000000000000.0);
+    test_p!(parse_13, "123456.123456", 123456.123456);
+    test_p!(parse_14, "+10", 10.0);
+    test_p!(parse_15, "1e2", 100.0);
+    test_p!(parse_16, "1e+2", 100.0);
+    test_p!(parse_17, "1E2", 100.0);
+    test_p!(parse_18, "1e-2", 0.01);
+    test_p!(parse_19, "1ex", 1.0);
+    test_p!(parse_20, "1em", 1.0);
+    test_p!(parse_21, "12345678901234567890", 12345678901234567000.0);
+    test_p!(parse_22, "0.", 0.0);
+    test_p!(parse_23, "1.3e-2", 0.013);
+    // test_number!(parse_24, "1e", 1.0); // TODO: this
+
+    macro_rules! test_p_err {
+        ($name:ident, $text:expr) => (
+            #[test]
+            fn $name() {
+                let mut s = Stream::from($text);
+                assert_eq!(s.parse_number().unwrap_err().to_string(),
+                           "invalid number at position 1");
+            }
+        )
+    }
+
+    test_p_err!(parse_err_1, "q");
+    test_p_err!(parse_err_2, "");
+    test_p_err!(parse_err_3, "-");
+    test_p_err!(parse_err_4, "+");
+    test_p_err!(parse_err_5, "-q");
+    test_p_err!(parse_err_6, ".");
+    test_p_err!(parse_err_7, "99999999e99999999");
+    test_p_err!(parse_err_8, "-99999999e99999999");
+}

--- a/crates/usvg-parser/src/stream.rs
+++ b/crates/usvg-parser/src/stream.rs
@@ -1,0 +1,448 @@
+// Copyright 2018 the SVG Types Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::Error;
+
+/// Extension methods for XML-subset only operations.
+pub(crate) trait ByteExt {
+    /// Checks if a byte is a numeric sign.
+    fn is_sign(&self) -> bool;
+
+    /// Checks if a byte is a digit.
+    ///
+    /// `[0-9]`
+    fn is_digit(&self) -> bool;
+
+    /// Checks if a byte is a hex digit.
+    ///
+    /// `[0-9A-Fa-f]`
+    fn is_hex_digit(&self) -> bool;
+
+    /// Checks if a byte is a space.
+    ///
+    /// `[ \r\n\t]`
+    fn is_space(&self) -> bool;
+
+    /// Checks if a byte is an ASCII ident char.
+    fn is_ascii_ident(&self) -> bool;
+}
+
+impl ByteExt for u8 {
+    #[inline]
+    fn is_sign(&self) -> bool {
+        matches!(*self, b'+' | b'-')
+    }
+
+    #[inline]
+    fn is_digit(&self) -> bool {
+        matches!(*self, b'0'..=b'9')
+    }
+
+    #[inline]
+    fn is_hex_digit(&self) -> bool {
+        matches!(*self, b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f')
+    }
+
+    #[inline]
+    fn is_space(&self) -> bool {
+        matches!(*self, b' ' | b'\t' | b'\n' | b'\r')
+    }
+
+    #[inline]
+    fn is_ascii_ident(&self) -> bool {
+        matches!(*self, b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z' | b'-' | b'_')
+    }
+}
+
+trait CharExt {
+    fn is_name_start(&self) -> bool;
+    fn is_name_char(&self) -> bool;
+    fn is_non_ascii(&self) -> bool;
+    fn is_escape(&self) -> bool;
+}
+
+impl CharExt for char {
+    #[inline]
+    fn is_name_start(&self) -> bool {
+        match *self {
+            '_' | 'a'..='z' | 'A'..='Z' => true,
+            _ => self.is_non_ascii() || self.is_escape(),
+        }
+    }
+
+    #[inline]
+    fn is_name_char(&self) -> bool {
+        match *self {
+            '_' | 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' => true,
+            _ => self.is_non_ascii() || self.is_escape(),
+        }
+    }
+
+    #[inline]
+    fn is_non_ascii(&self) -> bool {
+        *self as u32 > 237
+    }
+
+    #[inline]
+    fn is_escape(&self) -> bool {
+        // TODO: this
+        false
+    }
+}
+
+/// A streaming text parsing interface.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Stream<'a> {
+    text: &'a str,
+    pos: usize,
+}
+
+impl<'a> From<&'a str> for Stream<'a> {
+    #[inline]
+    fn from(text: &'a str) -> Self {
+        Stream { text, pos: 0 }
+    }
+}
+
+impl<'a> Stream<'a> {
+    /// Returns the current position in bytes.
+    #[inline]
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    /// Calculates the current position in chars.
+    pub fn calc_char_pos(&self) -> usize {
+        self.calc_char_pos_at(self.pos)
+    }
+
+    /// Calculates the current position in chars.
+    pub fn calc_char_pos_at(&self, byte_pos: usize) -> usize {
+        let mut pos = 1;
+        for (idx, _) in self.text.char_indices() {
+            if idx >= byte_pos {
+                break;
+            }
+
+            pos += 1;
+        }
+
+        pos
+    }
+
+    /// Sets current position equal to the end.
+    ///
+    /// Used to indicate end of parsing on error.
+    #[inline]
+    pub fn jump_to_end(&mut self) {
+        self.pos = self.text.len();
+    }
+
+    /// Checks if the stream is reached the end.
+    ///
+    /// Any [`pos()`] value larger than original text length indicates stream end.
+    ///
+    /// Accessing stream after reaching end via safe methods will produce
+    /// an `UnexpectedEndOfStream` error.
+    ///
+    /// Accessing stream after reaching end via *_unchecked methods will produce
+    /// a Rust's bound checking error.
+    ///
+    /// [`pos()`]: #method.pos
+    #[inline]
+    pub fn at_end(&self) -> bool {
+        self.pos >= self.text.len()
+    }
+
+    /// Returns a byte from a current stream position.
+    ///
+    /// # Errors
+    ///
+    /// - `UnexpectedEndOfStream`
+    #[inline]
+    pub fn curr_byte(&self) -> Result<u8, Error> {
+        if self.at_end() {
+            return Err(Error::UnexpectedEndOfStream);
+        }
+
+        Ok(self.curr_byte_unchecked())
+    }
+
+    #[inline]
+    pub fn chars(&self) -> std::str::Chars<'a> {
+        self.text[self.pos..].chars()
+    }
+
+    /// Returns a byte from a current stream position.
+    ///
+    /// # Panics
+    ///
+    /// - if the current position is after the end of the data
+    #[inline]
+    pub fn curr_byte_unchecked(&self) -> u8 {
+        self.text.as_bytes()[self.pos]
+    }
+
+    /// Checks that current byte is equal to provided.
+    ///
+    /// Returns `false` if no bytes left.
+    #[inline]
+    pub fn is_curr_byte_eq(&self, c: u8) -> bool {
+        if !self.at_end() {
+            self.curr_byte_unchecked() == c
+        } else {
+            false
+        }
+    }
+
+    /// Returns a next byte from a current stream position.
+    ///
+    /// # Errors
+    ///
+    /// - `UnexpectedEndOfStream`
+    #[inline]
+    pub fn next_byte(&self) -> Result<u8, Error> {
+        if self.pos + 1 >= self.text.len() {
+            return Err(Error::UnexpectedEndOfStream);
+        }
+
+        Ok(self.text.as_bytes()[self.pos + 1])
+    }
+
+    /// Advances by `n` bytes.
+    #[inline]
+    pub fn advance(&mut self, n: usize) {
+        debug_assert!(self.pos + n <= self.text.len());
+        self.pos += n;
+    }
+
+    /// Skips whitespaces.
+    ///
+    /// Accepted values: `' ' \n \r \t`.
+    pub fn skip_spaces(&mut self) {
+        while !self.at_end() && self.curr_byte_unchecked().is_space() {
+            self.advance(1);
+        }
+    }
+
+    /// Checks that the stream starts with a selected text.
+    ///
+    /// We are using `&[u8]` instead of `&str` for performance reasons.
+    #[inline]
+    pub fn starts_with(&self, text: &[u8]) -> bool {
+        self.text.as_bytes()[self.pos..].starts_with(text)
+    }
+
+    /// Consumes current byte if it's equal to the provided byte.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidChar`
+    /// - `UnexpectedEndOfStream`
+    pub fn consume_byte(&mut self, c: u8) -> Result<(), Error> {
+        if self.curr_byte()? != c {
+            return Err(Error::InvalidChar(
+                vec![self.curr_byte_unchecked(), c],
+                self.calc_char_pos(),
+            ));
+        }
+
+        self.advance(1);
+        Ok(())
+    }
+
+    /// Parses a single [ident](https://drafts.csswg.org/css-syntax-3/#typedef-ident-token).
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidIdent`
+    pub fn parse_ident(&mut self) -> Result<&'a str, Error> {
+        let start = self.pos();
+
+        if self.curr_byte() == Ok(b'-') {
+            self.advance(1);
+        }
+
+        let mut iter = self.chars();
+        if let Some(c) = iter.next() {
+            if c.is_name_start() {
+                self.advance(c.len_utf8());
+            } else {
+                return Err(Error::InvalidIdent);
+            }
+        }
+
+        for c in iter {
+            if c.is_name_char() {
+                self.advance(c.len_utf8());
+            } else {
+                break;
+            }
+        }
+
+        if start == self.pos() {
+            return Err(Error::InvalidIdent);
+        }
+
+        let name = self.slice_back(start);
+        Ok(name)
+    }
+
+    /// Consumes a single ident consisting of ASCII characters, if available.
+    pub fn consume_ascii_ident(&mut self) -> &'a str {
+        let start = self.pos;
+        self.skip_bytes(|_, c| c.is_ascii_ident());
+        self.slice_back(start)
+    }
+
+    /// Parses a single [quoted string](https://drafts.csswg.org/css-syntax-3/#typedef-string-token)
+    ///
+    /// # Errors
+    ///
+    /// - `UnexpectedEndOfStream`
+    /// - `InvalidValue`
+    pub fn parse_quoted_string(&mut self) -> Result<&'a str, Error> {
+        // Check for opening quote.
+        let quote = self.curr_byte()?;
+
+        if quote != b'\'' && quote != b'"' {
+            return Err(Error::InvalidValue);
+        }
+
+        let mut prev = quote;
+        self.advance(1);
+
+        let start = self.pos();
+
+        while !self.at_end() {
+            let curr = self.curr_byte_unchecked();
+
+            // Advance until the closing quote.
+            if curr == quote {
+                // Check for escaped quote.
+                if prev != b'\\' {
+                    break;
+                }
+            }
+
+            prev = curr;
+            self.advance(1);
+        }
+
+        let value = self.slice_back(start);
+
+        // Check for closing quote.
+        self.consume_byte(quote)?;
+
+        Ok(value)
+    }
+
+    /// Consumes selected string.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidChar`
+    /// - `UnexpectedEndOfStream`
+    pub fn consume_string(&mut self, text: &[u8]) -> Result<(), Error> {
+        if self.at_end() {
+            return Err(Error::UnexpectedEndOfStream);
+        }
+
+        if !self.starts_with(text) {
+            let len = std::cmp::min(text.len(), self.text.len() - self.pos);
+            // Collect chars and do not slice a string,
+            // because the `len` can be on the char boundary.
+            // Which lead to a panic.
+            let actual = self.text[self.pos..].chars().take(len).collect();
+
+            // Assume that all input `text` are valid UTF-8 strings, so unwrap is safe.
+            let expected = std::str::from_utf8(text).unwrap().to_owned();
+
+            return Err(Error::InvalidString(
+                vec![actual, expected],
+                self.calc_char_pos(),
+            ));
+        }
+
+        self.advance(text.len());
+        Ok(())
+    }
+
+    /// Consumes bytes by the predicate and returns them.
+    ///
+    /// The result can be empty.
+    pub fn consume_bytes<F>(&mut self, f: F) -> &'a str
+    where
+        F: Fn(&Stream, u8) -> bool,
+    {
+        let start = self.pos();
+        self.skip_bytes(f);
+        self.slice_back(start)
+    }
+
+    /// Consumes bytes by the predicate.
+    pub fn skip_bytes<F>(&mut self, f: F)
+    where
+        F: Fn(&Stream, u8) -> bool,
+    {
+        while !self.at_end() {
+            let c = self.curr_byte_unchecked();
+            if f(self, c) {
+                self.advance(1);
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Slices data from `pos` to the current position.
+    #[inline]
+    pub fn slice_back(&self, pos: usize) -> &'a str {
+        &self.text[pos..self.pos]
+    }
+
+    /// Slices data from the current position to the end.
+    #[inline]
+    pub fn slice_tail(&self) -> &'a str {
+        &self.text[self.pos..]
+    }
+
+    /// Parses number or percent from the stream.
+    ///
+    /// Percent value will be normalized.
+    pub fn parse_number_or_percent(&mut self) -> Result<f64, Error> {
+        self.skip_spaces();
+
+        let n = self.parse_number()?;
+        if self.starts_with(b"%") {
+            self.advance(1);
+            Ok(n / 100.0)
+        } else {
+            Ok(n)
+        }
+    }
+
+    /// Parses number or percent from a list of numbers and/or percents.
+    pub fn parse_list_number_or_percent(&mut self) -> Result<f64, Error> {
+        if self.at_end() {
+            return Err(Error::UnexpectedEndOfStream);
+        }
+
+        let l = self.parse_number_or_percent()?;
+        self.skip_spaces();
+        self.parse_list_separator();
+        Ok(l)
+    }
+
+    /// Skips digits.
+    pub fn skip_digits(&mut self) {
+        self.skip_bytes(|_, c| c.is_digit());
+    }
+
+    #[inline]
+    pub(crate) fn parse_list_separator(&mut self) {
+        if self.is_curr_byte_eq(b',') {
+            self.advance(1);
+        }
+    }
+}

--- a/crates/usvg-parser/src/stream.rs
+++ b/crates/usvg-parser/src/stream.rs
@@ -1,6 +1,10 @@
 // Copyright 2018 the SVG Types Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+// cmccall: Copied in from svgtypes repo b1cd4010f5e42f970932dbf01acc8f53547f64f6
+// Brought this in so that I could use parse_font_families. If possible, we may
+// want to consider updating the svgtypes crate dependency to 15.2+.
+
 use crate::Error;
 
 /// Extension methods for XML-subset only operations.

--- a/crates/usvg-parser/src/text.rs
+++ b/crates/usvg-parser/src/text.rs
@@ -8,8 +8,8 @@ use kurbo::{ParamCurve, ParamCurveArclen};
 use svgtypes::{Length, LengthUnit};
 use usvg_tree::*;
 
-use crate::font::{FontFamily, parse_font_families};
 use crate::clippath::resolve_transform;
+use crate::font::{parse_font_families, FontFamily};
 use crate::svgtree::{AId, EId, FromValue, SvgNode};
 use crate::{converter, style};
 
@@ -371,20 +371,18 @@ fn convert_font(node: SvgNode, state: &converter::State) -> Font {
     let stretch = conv_font_stretch(node);
     let weight = resolve_font_weight(node);
 
-    let font_families = if let Some(n) = node.ancestors().find(|n| n.has_attribute(AId::FontFamily)) {
+    let font_families = if let Some(n) = node.ancestors().find(|n| n.has_attribute(AId::FontFamily))
+    {
         n.attribute(AId::FontFamily).unwrap_or("")
     } else {
         ""
     };
 
-    let mut families = parse_font_families(font_families)
-    .ok()
-    .unwrap_or_default();
+    let mut families = parse_font_families(font_families).ok().unwrap_or_default();
 
     if families.is_empty() {
         families.push(FontFamily::Named(state.opt.font_family.clone()))
     }
-    
     let families = families.into_iter().map(|f| f.to_string()).collect();
 
     Font {


### PR DESCRIPTION
Fix for parsing font family declarations when there are multiple single-quoted family names