### PR TITLE
ESD-2927-fixed-cargo-clippy-issues-and-replace-cargo-wasi

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -4,7 +4,7 @@ jobs:
     build-and-test-resvg-0_36-epilog:
         runs-on: [ self-hosted, linux ]
         container:
-            image: ghcr.io/epiloglasercorp/epilog-rust-builder:1.83
+            image: ghcr.io/epiloglasercorp/epilog-rust-builder:1.84
         steps:
             - uses: actions/checkout@v3
               with:
@@ -12,4 +12,3 @@ jobs:
             - run: scripts/commit-check-formatting.sh
             - run: scripts/commit-build.sh
             - run: scripts/commit-test.sh
-            

--- a/scripts/commit-build.sh
+++ b/scripts/commit-build.sh
@@ -8,6 +8,6 @@ echo "Building release..."
 cargo build --release
 
 echo "Building wasi..."
-cargo wasi build --release
+cargo build --release --target wasm32-wasip2
 
 exit 0


### PR DESCRIPTION
Updated rust image to 1.84.0 to match the PrintAPI build process.