### PR TITLE
ESD-3282-add-support-for-css-image-rendering

### DIFF
--- a/crates/usvg-parser/src/svgtree/mod.rs
+++ b/crates/usvg-parser/src/svgtree/mod.rs
@@ -1008,6 +1008,10 @@ impl<'a, 'input: 'a> FromValue<'a, 'input> for usvg_tree::ImageRendering {
         match value {
             "auto" | "optimizeQuality" => Some(usvg_tree::ImageRendering::OptimizeQuality),
             "optimizeSpeed" => Some(usvg_tree::ImageRendering::OptimizeSpeed),
+            "smooth" => Some(usvg_tree::ImageRendering::Smooth),
+            "high-quality" => Some(usvg_tree::ImageRendering::HighQuality),
+            "crisp-edges" => Some(usvg_tree::ImageRendering::CrispEdges),
+            "pixelated" => Some(usvg_tree::ImageRendering::Pixelated),
             _ => None,
         }
     }

--- a/crates/usvg-tree/src/lib.rs
+++ b/crates/usvg-tree/src/lib.rs
@@ -167,6 +167,12 @@ impl std::str::FromStr for TextRendering {
 pub enum ImageRendering {
     OptimizeQuality,
     OptimizeSpeed,
+    // The following are copied from usvg 0.45.0.
+    // The following can only appear as presentation attributes.
+    Smooth,
+    HighQuality,
+    CrispEdges,
+    Pixelated,
 }
 
 impl Default for ImageRendering {
@@ -182,6 +188,10 @@ impl std::str::FromStr for ImageRendering {
         match s {
             "optimizeQuality" => Ok(ImageRendering::OptimizeQuality),
             "optimizeSpeed" => Ok(ImageRendering::OptimizeSpeed),
+            "smooth" => Ok(ImageRendering::Smooth),
+            "high-quality" => Ok(ImageRendering::HighQuality),
+            "crisp-edges" => Ok(ImageRendering::CrispEdges),
+            "pixelated" => Ok(ImageRendering::Pixelated),
             _ => Err("invalid"),
         }
     }

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -237,13 +237,29 @@ fn conv_filters(tree: &Tree, opt: &XmlOptions, xml: &mut XmlWriter) {
                     xml.start_svg_element(EId::FeImage);
                     xml.write_filter_primitive_attrs(fe);
                     xml.write_aspect(img.aspect);
-                    xml.write_svg_attribute(
-                        AId::ImageRendering,
-                        match img.rendering_mode {
-                            ImageRendering::OptimizeQuality => "optimizeQuality",
-                            ImageRendering::OptimizeSpeed => "optimizeSpeed",
-                        },
-                    );
+                    match img.rendering_mode {
+                        ImageRendering::OptimizeQuality => {
+                            xml.write_svg_attribute(AId::ImageRendering, "optimizeQuality");
+                        }
+                        ImageRendering::OptimizeSpeed => {
+                            xml.write_svg_attribute(AId::ImageRendering, "optimizeSpeed");
+                        }
+                        ImageRendering::Smooth => {
+                            xml.write_attribute(AId::Style.to_str(), "image-rendering:smooth");
+                        }
+                        ImageRendering::HighQuality => {
+                            xml.write_attribute(
+                                AId::Style.to_str(),
+                                "image-rendering:high-quality",
+                            );
+                        }
+                        ImageRendering::CrispEdges => {
+                            xml.write_attribute(AId::Style.to_str(), "image-rendering:crisp-edges");
+                        }
+                        ImageRendering::Pixelated => {
+                            xml.write_attribute(AId::Style.to_str(), "image-rendering:pixelated");
+                        }
+                    }
                     match img.data {
                         filter::ImageKind::Image(ref kind) => {
                             xml.write_image_data(kind);
@@ -603,6 +619,18 @@ fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut Xml
                 ImageRendering::OptimizeQuality => {}
                 ImageRendering::OptimizeSpeed => {
                     xml.write_svg_attribute(AId::ImageRendering, "optimizeSpeed");
+                }
+                ImageRendering::Smooth => {
+                    xml.write_attribute(AId::Style.to_str(), "image-rendering:smooth");
+                }
+                ImageRendering::HighQuality => {
+                    xml.write_attribute(AId::Style.to_str(), "image-rendering:high-quality");
+                }
+                ImageRendering::CrispEdges => {
+                    xml.write_attribute(AId::Style.to_str(), "image-rendering:crisp-edges");
+                }
+                ImageRendering::Pixelated => {
+                    xml.write_attribute(AId::Style.to_str(), "image-rendering:pixelated");
                 }
             }
 


### PR DESCRIPTION
Added support for parsing and passing along CSS image-rendering property.