### PR TITLE
ESD-3615-unknown-namespace-prefix-xlink

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,7 +2,8 @@ name: resvg-0_36-epilog-build-test
 on: [ pull_request, workflow_dispatch ]
 jobs:
     build-and-test-resvg-0_36-epilog:
-        runs-on: [ self-hosted, linux ]
+        runs-on:
+            group: self-hosted-linux
         container:
             image: ghcr.io/epiloglasercorp/epilog-rust-builder:1.84
         steps:

--- a/crates/usvg-tree/src/lib.rs
+++ b/crates/usvg-tree/src/lib.rs
@@ -1245,7 +1245,7 @@ pub trait NodeExt {
     ///
     /// If a current node doesn't support ID - an empty string
     /// will be returned.
-    fn id(&self) -> std::cell::Ref<str>;
+    fn id(&self) -> std::cell::Ref<'_, str>;
 
     /// Returns node's transform.
     ///
@@ -1297,7 +1297,7 @@ pub trait NodeExt {
 
 impl NodeExt for Node {
     #[inline]
-    fn id(&self) -> std::cell::Ref<str> {
+    fn id(&self) -> std::cell::Ref<'_, str> {
         std::cell::Ref::map(self.borrow(), |v| v.id())
     }
 

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -976,10 +976,10 @@ impl XmlWriterExt for XmlWriter {
             }
         };
 
-        self.write_attribute_raw("xlink:href", |buf| {
+        self.write_attribute_raw("href", |buf| {
             buf.extend_from_slice(b"data:image/");
             buf.extend_from_slice(mime.as_bytes());
-            buf.extend_from_slice(b";base64, ");
+            buf.extend_from_slice(b";base64,");
 
             let mut enc =
                 base64::write::EncoderWriter::new(buf, &base64::engine::general_purpose::STANDARD);


### PR DESCRIPTION
Image tags do not require the `xlink` namespace in front of `href` attribute. In fact, when feeding that into `roxmltree`/`usvg`, it can cause issues when an image is used as a mask.

Also fixed some Clippy complaints.